### PR TITLE
feat(terminal): 新增终端在线状态管理功能

### DIFF
--- a/terminal-application/src/main/java/com/colorlight/terminal/application/domain/CommonConstant.java
+++ b/terminal-application/src/main/java/com/colorlight/terminal/application/domain/CommonConstant.java
@@ -31,6 +31,11 @@ public final class CommonConstant {
 
         public static final String VERSION = "version";
 
+        public static final String TOTAL_ONLINE_TIME = "totalOnlineTime";
+
+        public static final String CREATED_AT = "createdAt";
+
+        public static final String UPDATED_AT = "updatedAt";
 
     }
 

--- a/terminal-application/src/main/java/com/colorlight/terminal/application/port/outbound/repository/TerminalOnlineStatusRepository.java
+++ b/terminal-application/src/main/java/com/colorlight/terminal/application/port/outbound/repository/TerminalOnlineStatusRepository.java
@@ -1,0 +1,37 @@
+package com.colorlight.terminal.application.port.outbound.repository;
+
+import com.colorlight.terminal.application.domain.status.OnlineStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * Mongo 持久化终端在线状态数据的仓储接口。
+ */
+public interface TerminalOnlineStatusRepository {
+
+    /**
+     * 创建或更新设备的在线状态，通常在上线或重连时调用。
+     *
+     * @param deviceId       设备 ID
+     * @param status         在线状态
+     * @param onlineStartTime 在线开始时间，可为 null
+     */
+    void upsertOnlineState(Long deviceId, OnlineStatus status, LocalDateTime onlineStartTime);
+
+    /**
+     * 仅更新设备的在线状态，不改变在线开始时间。
+     *
+     * @param deviceId 设备 ID
+     * @param status   在线状态
+     */
+    void updateStatus(Long deviceId, OnlineStatus status);
+
+    /**
+     * 结束一次在线会话，累加总在线时长并标记为离线。
+     *
+     * @param deviceId            设备 ID
+     * @param onlineStartTime     本次会话的上线时间
+     * @param sessionDurationSecs 会话持续时长（秒）
+     */
+    void finalizeOnlineSession(Long deviceId, LocalDateTime onlineStartTime, long sessionDurationSecs);
+}

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/event/DeviceStatusEventHandler.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/event/DeviceStatusEventHandler.java
@@ -1,10 +1,12 @@
 package com.colorlight.terminal.infrastructure.event;
 
 import com.colorlight.terminal.application.domain.status.DeviceStatusEvent;
+import com.colorlight.terminal.application.domain.status.OnlineStatus;
 import com.colorlight.terminal.application.dto.record.TerminalOnlineTimeRecord;
 import com.colorlight.terminal.application.dto.record.TerminalReconnectRecord;
 import com.colorlight.terminal.application.port.outbound.repository.TerminalAccountRepository;
 import com.colorlight.terminal.application.port.outbound.repository.TerminalOnlineTimeRepository;
+import com.colorlight.terminal.application.port.outbound.repository.TerminalOnlineStatusRepository;
 import com.colorlight.terminal.application.port.outbound.repository.TerminalReconnectRepository;
 import com.colorlight.terminal.application.port.outbound.rpc.MainServerRpcPort;
 import com.colorlight.terminal.application.port.outbound.status.AsyncTerminalLoginUpdatePort;
@@ -30,6 +32,7 @@ public class DeviceStatusEventHandler {
     
     private final TerminalAccountRepository terminalAccountRepository;
     private final TerminalOnlineTimeRepository terminalOnlineTimeRepository;
+    private final TerminalOnlineStatusRepository terminalOnlineStatusRepository;
     private final TerminalReconnectRepository  terminalReconnectRepository;
     private final AsyncTerminalLoginUpdatePort asyncTerminalLoginUpdatePort;
     private final MainServerRpcPort mainServerRpcPort;
@@ -38,12 +41,14 @@ public class DeviceStatusEventHandler {
     // 手动构造函数以支持@Qualifier注解
     public DeviceStatusEventHandler(TerminalAccountRepository terminalAccountRepository,
                                     TerminalOnlineTimeRepository terminalOnlineTimeRepository,
+                                    TerminalOnlineStatusRepository terminalOnlineStatusRepository,
                                     TerminalReconnectRepository terminalReconnectRepository,
                                     AsyncTerminalLoginUpdatePort asyncTerminalLoginUpdatePort,
                                     MainServerRpcPort mainServerRpcPort,
                                     @Qualifier("rpcNotificationExecutor") Executor rpcExecutor) {
         this.terminalAccountRepository = terminalAccountRepository;
         this.terminalOnlineTimeRepository = terminalOnlineTimeRepository;
+        this.terminalOnlineStatusRepository = terminalOnlineStatusRepository;
         this.terminalReconnectRepository = terminalReconnectRepository;
         this.asyncTerminalLoginUpdatePort = asyncTerminalLoginUpdatePort;
         this.mainServerRpcPort = mainServerRpcPort;
@@ -65,6 +70,12 @@ public class DeviceStatusEventHandler {
             updateLoginTimeImmediate(event);
             // 异步通知主服务（使用独立RPC线程池）
             rpcExecutor.execute(() -> notifyMainServerAsync(event));
+            // upsert 在线状态
+            terminalOnlineStatusRepository.upsertOnlineState(
+                    event.getDeviceId(),
+                    OnlineStatus.GO_LIVE,
+                    TimeUtils.convertTimestampToLocalDateTime(event.getEventTime())
+            );
         }
     }
 
@@ -79,12 +90,22 @@ public class DeviceStatusEventHandler {
             log.info("DeviceStatusEvent - 设备短时间重连事件: deviceId={}, source={}, clientIp={}",
                     event.getDeviceId(), event.getReportSource(), event.getClientIp());
             
+            LocalDateTime reconnectStartTime = event.getOnlineStartTime() != null
+                    ? TimeUtils.convertTimestampToLocalDateTime(event.getOnlineStartTime())
+                    : TimeUtils.convertTimestampToLocalDateTime(event.getEventTime());
+            
             // 重连时提交到缓冲池异步更新
             updateLoginTimeAsync(event);
             // 记录重连信息
             saveTerminalReconnect(event);
             // 异步通知主服务（使用独立RPC线程池）
             rpcExecutor.execute(() -> notifyMainServerAsync(event));
+            // upsert 在线状态
+            terminalOnlineStatusRepository.upsertOnlineState(
+                    event.getDeviceId(),
+                    OnlineStatus.RECONNECT,
+                    reconnectStartTime
+            );
         }
     }
     
@@ -219,8 +240,14 @@ public class DeviceStatusEventHandler {
                 .build();
 
         terminalOnlineTimeRepository.saveTerminalOnlineTime(onlineTimeRecord);
+        long durationSeconds = durationMs / 1000;
+        terminalOnlineStatusRepository.finalizeOnlineSession(
+                event.getDeviceId(),
+                TimeUtils.convertTimestampToLocalDateTime(event.getOnlineStartTime()),
+                durationSeconds
+        );
         log.debug("DeviceOnlineTime - 设备在线时长记录保存成功: deviceId={}, duration={}s",
-            event.getDeviceId(), durationMs / 1000);
+            event.getDeviceId(), durationSeconds);
     }
 
     // ==================== 终端异常重连记录辅助方法 ====================

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/persistence/mongodb/document/TerminalOnlineStatusDocument.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/persistence/mongodb/document/TerminalOnlineStatusDocument.java
@@ -1,0 +1,44 @@
+package com.colorlight.terminal.infrastructure.persistence.mongodb.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document("terminal_online_status")
+public class TerminalOnlineStatusDocument {
+
+    @Id
+    private String objectId;
+
+    @Indexed(unique = true)
+    private Long deviceId;
+
+    /**
+     * 累计在线时长（秒）
+     */
+    private Long totalOnlineTime;
+
+    /**
+     * 本轮在线起始时间
+     */
+    private LocalDateTime onlineStartTime;
+
+    /**
+     * 当前在线状态字符串表示
+     */
+    private String status;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/persistence/mongodb/repository/MongoTerminalOnlineStatusRepository.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/persistence/mongodb/repository/MongoTerminalOnlineStatusRepository.java
@@ -1,0 +1,111 @@
+package com.colorlight.terminal.infrastructure.persistence.mongodb.repository;
+
+import com.colorlight.terminal.application.domain.status.OnlineStatus;
+import com.colorlight.terminal.application.port.outbound.repository.TerminalOnlineStatusRepository;
+import com.colorlight.terminal.infrastructure.persistence.mongodb.document.TerminalOnlineStatusDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+import static com.colorlight.terminal.application.domain.CommonConstant.Device.CREATED_AT;
+import static com.colorlight.terminal.application.domain.CommonConstant.Device.DEVICE_ID;
+import static com.colorlight.terminal.application.domain.CommonConstant.Device.ONLINE_START_TIME;
+import static com.colorlight.terminal.application.domain.CommonConstant.Device.STATUS;
+import static com.colorlight.terminal.application.domain.CommonConstant.Device.TOTAL_ONLINE_TIME;
+import static com.colorlight.terminal.application.domain.CommonConstant.Device.UPDATED_AT;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MongoTerminalOnlineStatusRepository implements TerminalOnlineStatusRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void upsertOnlineState(Long deviceId, OnlineStatus status, LocalDateTime onlineStartTime) {
+        if (deviceId == null || status == null) {
+            log.warn("TerminalOnlineStatus - 跳过处理，无效参数: deviceId={}, status={}", deviceId, status);
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        Query query = Query.query(Criteria.where(DEVICE_ID).is(deviceId));
+        Update update = new Update()
+                .set(STATUS, normalizeStatus(status))
+                .set(UPDATED_AT, now)
+                .setOnInsert(DEVICE_ID, deviceId)
+                .setOnInsert(TOTAL_ONLINE_TIME, 0L)
+                .setOnInsert(CREATED_AT, now);
+
+        if (onlineStartTime != null) {
+            update.set(ONLINE_START_TIME, onlineStartTime);
+        }
+
+        try {
+            mongoTemplate.upsert(query, update, TerminalOnlineStatusDocument.class);
+            log.debug("TerminalOnlineStatus - upsert状态成功: deviceId={}, status={}", deviceId, normalizeStatus(status));
+        } catch (Exception e) {
+            log.error("TerminalOnlineStatus - upsert状态失败: deviceId={}, status={}", deviceId, normalizeStatus(status), e);
+        }
+    }
+
+    @Override
+    public void updateStatus(Long deviceId, OnlineStatus status) {
+        if (deviceId == null || status == null) {
+            log.warn("TerminalOnlineStatus - 跳过状态更新, 无效的参数: deviceId={}, status={}", deviceId, status);
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        Query query = Query.query(Criteria.where(DEVICE_ID).is(deviceId));
+        Update update = new Update()
+                .set(STATUS, normalizeStatus(status))
+                .set(UPDATED_AT, now)
+                .setOnInsert(DEVICE_ID, deviceId)
+                .setOnInsert(TOTAL_ONLINE_TIME, 0L)
+                .setOnInsert(CREATED_AT, now);
+        try {
+            mongoTemplate.upsert(query, update, TerminalOnlineStatusDocument.class);
+            log.debug("TerminalOnlineStatus - 更新状态成功: deviceId={}, status={}", deviceId, normalizeStatus(status));
+        } catch (Exception e) {
+            log.error("TerminalOnlineStatus - 状态更新失败: deviceId={}, status={}", deviceId, normalizeStatus(status), e);
+        }
+    }
+
+    @Override
+    public void finalizeOnlineSession(Long deviceId, LocalDateTime onlineStartTime, long sessionDurationSecs) {
+        if (deviceId == null || sessionDurationSecs <= 0) {
+            log.warn("TerminalOnlineStatus - 跳过在线时长累计处理, 无效的参数: deviceId={}, duration={}", deviceId, sessionDurationSecs);
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        Query query = Query.query(Criteria.where(DEVICE_ID).is(deviceId));
+        Update update = new Update()
+                .inc(TOTAL_ONLINE_TIME, sessionDurationSecs)
+                .set(STATUS, OnlineStatus.OFFLINE.name())
+                .set(UPDATED_AT, now)
+                .setOnInsert(DEVICE_ID, deviceId)
+                .setOnInsert(CREATED_AT, now);
+
+        if (onlineStartTime != null) {
+            update.set(ONLINE_START_TIME, onlineStartTime);
+        }
+        try {
+            mongoTemplate.upsert(query, update, TerminalOnlineStatusDocument.class);
+            log.debug("TerminalOnlineStatus - 在线时长累计成功: deviceId={}, addedDuration={}s", deviceId, sessionDurationSecs);
+        } catch (Exception e) {
+            log.error("TerminalOnlineStatus - 在线时长累计失败: deviceId={}, addedDuration={}s", deviceId, sessionDurationSecs, e);
+        }
+    }
+
+    private String normalizeStatus(OnlineStatus status) {
+        return status == OnlineStatus.OFFLINE ? OnlineStatus.OFFLINE.name() : OnlineStatus.ONLINE.name();
+    }
+}

--- a/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/event/DeviceStatusEventHandlerTest.java
+++ b/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/event/DeviceStatusEventHandlerTest.java
@@ -1,14 +1,17 @@
 package com.colorlight.terminal.infrastructure.event;
 
 import com.colorlight.terminal.application.domain.status.DeviceStatusEvent;
+import com.colorlight.terminal.application.domain.status.OnlineStatus;
 import com.colorlight.terminal.application.domain.status.ReportSource;
 import com.colorlight.terminal.application.dto.record.TerminalOnlineTimeRecord;
 import com.colorlight.terminal.application.dto.record.TerminalReconnectRecord;
 import com.colorlight.terminal.application.port.outbound.repository.TerminalAccountRepository;
 import com.colorlight.terminal.application.port.outbound.repository.TerminalOnlineTimeRepository;
+import com.colorlight.terminal.application.port.outbound.repository.TerminalOnlineStatusRepository;
 import com.colorlight.terminal.application.port.outbound.repository.TerminalReconnectRepository;
 import com.colorlight.terminal.application.port.outbound.rpc.MainServerRpcPort;
 import com.colorlight.terminal.application.port.outbound.status.AsyncTerminalLoginUpdatePort;
+import com.colorlight.terminal.commons.utils.TimeUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +26,7 @@ import java.util.concurrent.Executor;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.*;
 
 /**
@@ -55,6 +59,9 @@ class DeviceStatusEventHandlerTest {
     private TerminalOnlineTimeRepository terminalOnlineTimeRepository;
     
     @Mock
+    private TerminalOnlineStatusRepository terminalOnlineStatusRepository;
+    
+    @Mock
     private TerminalReconnectRepository terminalReconnectRepository;
     
     @Mock
@@ -82,6 +89,7 @@ class DeviceStatusEventHandlerTest {
         deviceStatusEventHandler = new DeviceStatusEventHandler(
                 terminalAccountRepository,
                 terminalOnlineTimeRepository,
+                terminalOnlineStatusRepository,
                 terminalReconnectRepository,
                 asyncTerminalLoginUpdatePort,
                 mainServerRpcPort,
@@ -105,8 +113,11 @@ class DeviceStatusEventHandlerTest {
         assertDoesNotThrow(() -> deviceStatusEventHandler.handleDeviceOnline(goLiveEvent));
 
         // Then: 验证立即更新登录时间被调用
+        LocalDateTime expectedGoLiveStart = TimeUtils.convertTimestampToLocalDateTime(currentTime);
         then(terminalAccountRepository).should().updateLoginTimeImmediate(
                 eq(sampleDeviceId), eq(sampleClientIp), any(LocalDateTime.class));
+        then(terminalOnlineStatusRepository).should().upsertOnlineState(
+                eq(sampleDeviceId), eq(OnlineStatus.GO_LIVE), eq(expectedGoLiveStart));
         
         // 验证RPC通知被调用（通过Executor异步执行）
         ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -132,6 +143,7 @@ class DeviceStatusEventHandlerTest {
 
         // Then: 验证不执行任何操作
         then(terminalAccountRepository).should(never()).updateLoginTimeImmediate(any(), any(), any());
+        then(terminalOnlineStatusRepository).should(never()).upsertOnlineState(any(), any(), any());
         then(rpcExecutor).should(never()).execute(any(Runnable.class));
     }
 
@@ -158,6 +170,9 @@ class DeviceStatusEventHandlerTest {
         // Then: 验证异步更新登录时间被调用
         then(asyncTerminalLoginUpdatePort).should().submitLoginUpdate(
                 eq(sampleDeviceId), eq(sampleClientIp), any(LocalDateTime.class));
+        LocalDateTime expectedReconnectStart = TimeUtils.convertTimestampToLocalDateTime(onlineStartTime);
+        then(terminalOnlineStatusRepository).should().upsertOnlineState(
+                eq(sampleDeviceId), eq(OnlineStatus.RECONNECT), eq(expectedReconnectStart));
         
         // 验证保存重连记录被调用
         ArgumentCaptor<TerminalReconnectRecord> reconnectCaptor = ArgumentCaptor.forClass(TerminalReconnectRecord.class);
@@ -194,8 +209,10 @@ class DeviceStatusEventHandlerTest {
 
         // When: 处理设备离线事件
         deviceStatusEventHandler.handleDetectedDeviceOffline(offlineEvent);
+        long expectedDurationSeconds = (lastReportTime - onlineStartTime) / 1000;
+        LocalDateTime expectedSessionStart = TimeUtils.convertTimestampToLocalDateTime(onlineStartTime);
 
-        // Then: 验证保存在线时长记录被调用
+        // Then: 验证在线时长被记录
         ArgumentCaptor<TerminalOnlineTimeRecord> onlineTimeCaptor = ArgumentCaptor.forClass(TerminalOnlineTimeRecord.class);
         then(terminalOnlineTimeRepository).should().saveTerminalOnlineTime(onlineTimeCaptor.capture());
         
@@ -203,7 +220,14 @@ class DeviceStatusEventHandlerTest {
         assertEquals(sampleDeviceId, savedRecord.getDeviceId());
         assertNotNull(savedRecord.getStartTime());
         assertNotNull(savedRecord.getEndTime());
+                ArgumentCaptor<LocalDateTime> sessionStartCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<Long> durationCaptor = ArgumentCaptor.forClass(Long.class);
+        then(terminalOnlineStatusRepository).should().finalizeOnlineSession(
+                eq(sampleDeviceId), sessionStartCaptor.capture(), durationCaptor.capture());
+        assertEquals(expectedSessionStart, sessionStartCaptor.getValue());
+        assertEquals(expectedDurationSeconds, durationCaptor.getValue().longValue());
     }
+
 
     @Test
     @DisplayName("处理设备检测离线事件 - 时间为空")
@@ -222,6 +246,8 @@ class DeviceStatusEventHandlerTest {
 
         // Then: 验证不保存在线时长记录
         then(terminalOnlineTimeRepository).should(never()).saveTerminalOnlineTime(any());
+        then(terminalOnlineStatusRepository).should(never()).finalizeOnlineSession(any(), any(LocalDateTime.class), anyLong());
+        then(terminalOnlineStatusRepository).should(never()).finalizeOnlineSession(any(), any(LocalDateTime.class), anyLong());
     }
 
     @Test
@@ -237,10 +263,12 @@ class DeviceStatusEventHandlerTest {
         // When: 处理事件（仅记录日志，无其他操作）
         assertDoesNotThrow(() -> deviceStatusEventHandler.handleConfirmDeviceOffline(confirmOfflineEvent));
 
-        // Then: 验证没有调用任何业务操作
+        // Then: 验证仅更新Mongo状态，不触发其他业务操作
+        then(terminalOnlineStatusRepository).should(never()).updateStatus(any(), any());
         then(terminalAccountRepository).should(never()).updateLoginTimeImmediate(any(), any(), any());
         then(asyncTerminalLoginUpdatePort).should(never()).submitLoginUpdate(any(), any(), any());
         then(terminalOnlineTimeRepository).should(never()).saveTerminalOnlineTime(any());
+        then(terminalOnlineStatusRepository).should(never()).finalizeOnlineSession(any(), any(LocalDateTime.class), anyLong());
     }
 
     @Test
@@ -261,6 +289,7 @@ class DeviceStatusEventHandlerTest {
         // Then: 验证异步更新登录时间被调用
         then(asyncTerminalLoginUpdatePort).should().submitLoginUpdate(
                 eq(sampleDeviceId), eq(sampleClientIp), any(LocalDateTime.class));
+        then(terminalOnlineStatusRepository).should(never()).updateStatus(any(), any());
         
         // 验证RPC通知被调用（通过Executor异步执行）
         ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -377,6 +406,8 @@ class DeviceStatusEventHandlerTest {
 
         // Then: 验证异步更新被调用，异常被捕获
         then(asyncTerminalLoginUpdatePort).should().submitLoginUpdate(any(), any(), any());
+        then(terminalOnlineStatusRepository).should().upsertOnlineState(
+                eq(sampleDeviceId), eq(OnlineStatus.RECONNECT), eq(TimeUtils.convertTimestampToLocalDateTime(currentTime - 3600000L)));
         // 其他操作仍然应该正常执行
         then(terminalReconnectRepository).should().saveReconnectRecord(any());
         // RPC通知仍然应该被调用（通过Executor异步执行）
@@ -408,6 +439,7 @@ class DeviceStatusEventHandlerTest {
 
         // Then: 验证不保存在线时长记录（因为时间顺序异常）
         then(terminalOnlineTimeRepository).should(never()).saveTerminalOnlineTime(any());
+        then(terminalOnlineStatusRepository).should(never()).finalizeOnlineSession(any(), any(LocalDateTime.class), anyLong());
     }
 
     @Test
@@ -449,6 +481,7 @@ class DeviceStatusEventHandlerTest {
 
         // When: 处理连接时长刚好1秒的离线事件
         assertDoesNotThrow(() -> deviceStatusEventHandler.handleDetectedDeviceOffline(boundaryEvent));
+        long expectedDurationSeconds = 1L;
 
         // Then: 验证保存在线时长记录（因为连接时长等于1秒，符合要求）
         ArgumentCaptor<TerminalOnlineTimeRecord> recordCaptor = ArgumentCaptor.forClass(TerminalOnlineTimeRecord.class);
@@ -458,5 +491,11 @@ class DeviceStatusEventHandlerTest {
         assertEquals(sampleDeviceId, savedRecord.getDeviceId());
         assertNotNull(savedRecord.getStartTime());
         assertNotNull(savedRecord.getEndTime());
+                ArgumentCaptor<LocalDateTime> boundaryStartCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<Long> boundaryDurationCaptor = ArgumentCaptor.forClass(Long.class);
+        then(terminalOnlineStatusRepository).should().finalizeOnlineSession(
+                eq(sampleDeviceId), boundaryStartCaptor.capture(), boundaryDurationCaptor.capture());
+        assertEquals(TimeUtils.convertTimestampToLocalDateTime(boundaryOnlineStartTime), boundaryStartCaptor.getValue());
+        assertEquals(expectedDurationSeconds, boundaryDurationCaptor.getValue().longValue());
     }
 }


### PR DESCRIPTION
- 在 CommonConstant 中添加在线状态相关常量
- 新增 TerminalOnlineStatusRepository 接口及 Mongo 实现- 扩展 DeviceStatusEventHandler以处理在线状态变更
- 添加 TerminalOnlineStatusDocument用于 MongoDB 持久化
- 更新事件处理逻辑，支持记录在线时长和状态变更
- 完善单元测试覆盖新增的在线状态管理逻辑