### PR TITLE
feat(sensor):重构传感器数据上报处理逻辑

### DIFF
--- a/terminal-application/src/main/java/com/colorlight/terminal/application/port/inbound/status/TerminalReportUseCase.java
+++ b/terminal-application/src/main/java/com/colorlight/terminal/application/port/inbound/status/TerminalReportUseCase.java
@@ -2,6 +2,7 @@ package com.colorlight.terminal.application.port.inbound.status;
 
 import com.colorlight.terminal.application.domain.report.TerminalLog;
 import com.colorlight.terminal.application.domain.report.TerminalStatusReport;
+import com.colorlight.terminal.application.domain.sensor.SensorReport;
 import com.colorlight.terminal.application.dto.record.ScreenshotUploadRecord;
 
 import java.time.LocalDateTime;
@@ -53,9 +54,9 @@ public interface TerminalReportUseCase {
      * 处理传感器上报
      * @param deviceId 设备Id
      * @param reportTime 上报时间
-     * @param reportStr 上报Json
+     * @param reports 传感器上报数据列表
      */
-    void asyncHandleSensorReport(Long deviceId, LocalDateTime reportTime, String reportStr);
+    void asyncHandleSensorReport(Long deviceId, LocalDateTime reportTime, List<SensorReport> reports);
 
     /**
      * 异步保存设备截图。

--- a/terminal-application/src/main/java/com/colorlight/terminal/application/service/TerminalReportApplicationService.java
+++ b/terminal-application/src/main/java/com/colorlight/terminal/application/service/TerminalReportApplicationService.java
@@ -150,43 +150,33 @@ public class TerminalReportApplicationService implements TerminalReportUseCase {
      * 异步处理传感器上报数据
      * @param deviceId 设备Id
      * @param reportTime 上报时间
-     * @param reportStr 上报Json
+     * @param reports 传感器上报数据列表
      */
     @Override
     @Async("statisticsReportExecutor")
-    public void asyncHandleSensorReport(Long deviceId, LocalDateTime reportTime, String reportStr) {
+    public void asyncHandleSensorReport(Long deviceId, LocalDateTime reportTime, List<SensorReport> reports) {
         try {
-
-            // 适配HTTP上报封装
-            final JsonNode jsonNode = JsonUtils.fromJson(reportStr);
-            if (jsonNode.has("gps")) {
-                reportStr = jsonNode.get("gps").toString();
-            }
-
-            // JSON反序列化
-            List<SensorReport> reports = JsonUtils.fromJson(reportStr, new TypeReference<List<SensorReport>>() {});
             if (CollectionUtils.isEmpty(reports)) {
                 log.debug("ApplicationService -SensorReport- 空的传感器数据: deviceId={}", deviceId);
                 return;
             }
-            
+
             // 按类型处理
             for (SensorReport report : reports) {
                 if (report == null || report.getSensorType() == null) {
                     log.warn("ApplicationService -SensorReport- 传感器数据格式无效: deviceId={}, report={}", deviceId, report);
                     continue;
                 }
-                
+
                 if ("gps".equals(report.getSensorType()) && report instanceof GpsReport gpsReport) {
                     processGpsReport(deviceId, reportTime, gpsReport);
                 } else {
                     processOtherReport(deviceId, report);
                 }
             }
-            
+
         } catch (Exception e) {
-            log.error("ApplicationService -SensorReport- 处理传感器数据异常: deviceId={}, reportStr={}", 
-                    deviceId, reportStr != null ? reportStr.substring(0, Math.min(100, reportStr.length())) : "null", e);
+            log.error("ApplicationService -SensorReport- 处理传感器数据异常: deviceId={}", deviceId, e);
             throw new BusinessException(CommonErrorCode.OPERATION_FAILED, "传感器数据处理失败", e);
         }
     }

--- a/terminal-application/src/test/java/com/colorlight/terminal/application/service/TerminalReportApplicationServiceTest.java
+++ b/terminal-application/src/test/java/com/colorlight/terminal/application/service/TerminalReportApplicationServiceTest.java
@@ -449,17 +449,8 @@ class TerminalReportApplicationServiceTest extends BaseApplicationServiceTest {
             // Given - GPS传感器报告
             List<SensorReport> gpsReports = TestDataBuilder.createGpsSensorReports();
 
-            // Mock JsonNode (第一次调用) - 返回空的ObjectNode（没有"gps"字段）
-            ObjectNode emptyNode = OBJECT_MAPPER.createObjectNode();
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(TEST_SENSOR_REPORT_STR))
-                         .thenReturn(emptyNode);
-
-            // Mock List<SensorReport> (第二次调用)
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(eq(TEST_SENSOR_REPORT_STR), any(TypeReference.class)))
-                         .thenReturn(gpsReports);
-
             // When - 处理传感器报告
-            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, TEST_SENSOR_REPORT_STR);
+            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, gpsReports);
 
             // Then - 验证GPS处理
             verify(deviceGpsHandlePort).receiveGpsRecord(gpsReportCaptor.capture());
@@ -476,17 +467,8 @@ class TerminalReportApplicationServiceTest extends BaseApplicationServiceTest {
             // Given - 无效GPS报告
             List<SensorReport> invalidGpsReports = List.of(TestDataBuilder.createInvalidGpsReport());
 
-            // Mock JsonNode (第一次调用) - 返回空的ObjectNode（没有"gps"字段）
-            ObjectNode emptyNode = OBJECT_MAPPER.createObjectNode();
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(TEST_SENSOR_REPORT_STR))
-                         .thenReturn(emptyNode);
-
-            // Mock List<SensorReport> (第二次调用)
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(eq(TEST_SENSOR_REPORT_STR), any(TypeReference.class)))
-                         .thenReturn(invalidGpsReports);
-
             // When - 处理传感器报告
-            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, TEST_SENSOR_REPORT_STR);
+            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, invalidGpsReports);
 
             // Then - 验证无效GPS报告被跳过
             verify(deviceGpsHandlePort, never()).receiveGpsRecord(any());
@@ -498,17 +480,8 @@ class TerminalReportApplicationServiceTest extends BaseApplicationServiceTest {
             // Given - 其他类型传感器报告
             List<SensorReport> otherReports = TestDataBuilder.createOtherSensorReports();
 
-            // Mock JsonNode (第一次调用) - 返回空的ObjectNode（没有"gps"字段）
-            ObjectNode emptyNode = OBJECT_MAPPER.createObjectNode();
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(TEST_SENSOR_REPORT_STR))
-                         .thenReturn(emptyNode);
-
-            // Mock List<SensorReport> (第二次调用)
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(eq(TEST_SENSOR_REPORT_STR), any(TypeReference.class)))
-                         .thenReturn(otherReports);
-
             // When - 处理传感器报告
-            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, TEST_SENSOR_REPORT_STR);
+            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, otherReports);
 
             // Then - 验证其他类型传感器报告被处理（仅debug日志）
             verify(deviceGpsHandlePort, never()).receiveGpsRecord(any());
@@ -519,17 +492,8 @@ class TerminalReportApplicationServiceTest extends BaseApplicationServiceTest {
         void should_return_early_when_sensor_reports_empty() {
             // Given - 空传感器报告列表
 
-            // Mock JsonNode (第一次调用) - 返回空的ObjectNode（没有"gps"字段）
-            ObjectNode emptyNode = OBJECT_MAPPER.createObjectNode();
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(TEST_SENSOR_REPORT_STR))
-                         .thenReturn(emptyNode);
-
-            // Mock List<SensorReport> (第二次调用)
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(eq(TEST_SENSOR_REPORT_STR), any(TypeReference.class)))
-                         .thenReturn(Collections.emptyList());
-
             // When - 处理传感器报告
-            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, TEST_SENSOR_REPORT_STR);
+            service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, Collections.emptyList());
 
             // Then - 验证提前返回，没有进一步处理
             verify(deviceGpsHandlePort, never()).receiveGpsRecord(any());
@@ -538,12 +502,13 @@ class TerminalReportApplicationServiceTest extends BaseApplicationServiceTest {
         @Test
         @DisplayName("应该在传感器报告处理异常时抛出业务异常")
         void should_throw_business_exception_when_sensor_report_processing_fails() {
-            // Given - JSON解析失败
-            jsonUtilsMock.when(() -> JsonUtils.fromJson(eq(TEST_SENSOR_REPORT_STR), any(TypeReference.class)))
-                         .thenThrow(new RuntimeException("JSON解析失败"));
-            
+            // Given - GPS处理失败
+            List<SensorReport> gpsReports = TestDataBuilder.createGpsSensorReports();
+            doThrow(new RuntimeException("GPS处理失败"))
+                    .when(deviceGpsHandlePort).receiveGpsRecord(any());
+
             // When & Then - 验证抛出业务异常
-            assertThatThrownBy(() -> service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, TEST_SENSOR_REPORT_STR))
+            assertThatThrownBy(() -> service.asyncHandleSensorReport(TEST_DEVICE_ID, TEST_REPORT_TIME, gpsReports))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", "TM0004")
                     .hasMessageContaining("传感器数据处理失败")

--- a/terminal-boot/src/main/java/com/colorlight/terminal/boot/controller/DeviceInteractionController.java
+++ b/terminal-boot/src/main/java/com/colorlight/terminal/boot/controller/DeviceInteractionController.java
@@ -264,13 +264,9 @@ public class DeviceInteractionController implements DeviceInteractionApi {
         }
 
         try {
-            // 协议适配：处理 {"gps": [...]} 包裹格式
-            JsonNode jsonNode = JsonUtils.fromJson(report);
-            String unwrappedJson = jsonNode.has("gps") ? jsonNode.get("gps").toString() : report;
-
             // 反序列化为领域对象
             List<SensorReport> reports = JsonUtils.fromJson(
-                    unwrappedJson,
+                    report,
                     new TypeReference<List<SensorReport>>() {}
             );
 

--- a/terminal-boot/src/main/java/com/colorlight/terminal/boot/controller/DeviceInteractionController.java
+++ b/terminal-boot/src/main/java/com/colorlight/terminal/boot/controller/DeviceInteractionController.java
@@ -35,6 +35,9 @@ import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.colorlight.terminal.application.domain.sensor.SensorReport;
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * 设备交互控制器 - 实现设备二次开发文档中的必须接口
  * <p>由于老版本遗留问题使用Integer做设备Id，这里进行适配使用Auth认证中的Long Id</p>
@@ -255,10 +258,32 @@ public class DeviceInteractionController implements DeviceInteractionApi {
         LocalDateTime now = LocalDateTime.now();
         TerminalPrincipal principal = (TerminalPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         log.debug("DeviceSensorData - 终端 {} 上报传感器数据: {}", principal.getDeviceId(), report);
-        if (StringUtils.isBlank(report)) return ResponseEntity.status(HttpStatus.CREATED).build();
-        terminalReportUseCase.asyncHandleSensorReport(principal.getDeviceId(), now, report);
+
+        if (StringUtils.isBlank(report)) {
+            return ResponseEntity.status(HttpStatus.CREATED).build();
+        }
+
+        try {
+            // 协议适配：处理 {"gps": [...]} 包裹格式
+            JsonNode jsonNode = JsonUtils.fromJson(report);
+            String unwrappedJson = jsonNode.has("gps") ? jsonNode.get("gps").toString() : report;
+
+            // 反序列化为领域对象
+            List<SensorReport> reports = JsonUtils.fromJson(
+                    unwrappedJson,
+                    new TypeReference<List<SensorReport>>() {}
+            );
+
+            terminalReportUseCase.asyncHandleSensorReport(principal.getDeviceId(), now, reports);
+
+        } catch (Exception e) {
+            log.error("DeviceSensorData - 终端 {} 反序列化传感器数据失败", principal.getDeviceId(), e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
 
     /**
      * 该方法用于处理终端通过HTTP接口上报的日志信息。

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v10/V10ProtocolMessageProcessor.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v10/V10ProtocolMessageProcessor.java
@@ -2,6 +2,7 @@ package com.colorlight.terminal.infrastructure.websocket.processor.v10;
 
 import com.colorlight.terminal.application.domain.connection.MessageProcessingContext;
 import com.colorlight.terminal.application.domain.connection.ProtocolVersion;
+import com.colorlight.terminal.application.domain.sensor.SensorReport;
 import com.colorlight.terminal.application.dto.websocket.v10.V10WebsocketMessage;
 import com.colorlight.terminal.application.port.inbound.status.TerminalReportUseCase;
 import com.colorlight.terminal.application.port.outbound.websocket.ProtocolMessageProcessor;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * V1.0协议消息处理器 - Infrastructure层实现
@@ -89,25 +92,17 @@ public class V10ProtocolMessageProcessor implements ProtocolMessageProcessor {
         return TextMessageProcessResult.ofFailure("PONG消息发送失败");
     }
 
-    /**
-     * 处理GPS上报
-     * @param context 上下文
-     * @param message 封装消息体
-     * @return 处理结果
-     */
     private TextMessageProcessResult handleGpsMessage(MessageProcessingContext context, V10WebsocketMessage message) {
 
         log.debug("V10ProtocolMessageProcessor - 处理GPS数据: deviceId={}, count={}",
                 context.getDeviceId(), message.getGps().size());
 
-        // 将List<GpsReport>序列化为JSON字符串传递给应用服务
-        String gpsJson = JsonUtils.toJson(message.getGps());
-
-        // 异步处理传感器数据上报
+        // 直接传递List对象给应用服务
+        List<SensorReport> sensorReports = new ArrayList<>(message.getGps());
         terminalReportUseCase.asyncHandleSensorReport(
                 context.getDeviceId(),
                 LocalDateTime.now(),
-                gpsJson
+                sensorReports
         );
 
         log.debug("V10ProtocolMessageProcessor - GPS数据处理提交成功: deviceId={}",
@@ -115,4 +110,5 @@ public class V10ProtocolMessageProcessor implements ProtocolMessageProcessor {
 
         return TextMessageProcessResult.ofSuccess(false);
     }
+
 }

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouter.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouter.java
@@ -377,17 +377,31 @@ public class V11OperationHandleRouter {
      * 处理传感器数据报告的命令。
      * V11协议：data字段为List<SensorReport>格式
      *
+     * <p>注意：由于V11WebsocketMessage.data是Object类型，JSON反序列化后会产生ArrayList<LinkedHashMap>
+     * 而不是ArrayList<SensorReport>，因此需要使用JsonUtils.convertValue()进行类型转换</p>
+     *
      * @param context 消息处理上下文，包含设备ID等信息
      * @param message 接收到的WebSocket消息对象
      */
     private void handleSensorDataReport(MessageProcessingContext context, V11WebsocketMessage message) {
         LocalDateTime now = LocalDateTime.now();
 
-        // V11协议: data字段直接为List<SensorReport>格式
-        @SuppressWarnings("unchecked")
-        List<SensorReport> reports = Objects.isNull(message.getData())
-                ? List.of()
-                : (List<SensorReport>) message.getData();
+        // 由JSON反序列化得到的data是ArrayList<LinkedHashMap>，需要转换为List<SensorReport>
+        List<SensorReport> reports;
+        if (Objects.isNull(message.getData())) {
+            reports = List.of();
+        } else {
+            try {
+                reports = JsonUtils.convertValue(message.getData(), new TypeReference<List<SensorReport>>() {});
+                if (reports == null) {
+                    reports = List.of();
+                }
+            } catch (Exception e) {
+                log.error("V11Router -ws- #MONITOR_REPORT#【传感器数据转换失败】deviceId:{}, data:{}",
+                        context.getDeviceId(), message.getData(), e);
+                reports = List.of();
+            }
+        }
 
         terminalReportUseCase.asyncHandleSensorReport(context.getDeviceId(), now, reports);
         log.info("V11Router -ws- #MONITOR_REPORT#【上报监控数据】 deviceId:{}", context.getDeviceId());

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouter.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouter.java
@@ -375,6 +375,7 @@ public class V11OperationHandleRouter {
 
     /**
      * 处理传感器数据报告的命令。
+     * V11协议：data字段为List<SensorReport>格式
      *
      * @param context 消息处理上下文，包含设备ID等信息
      * @param message 接收到的WebSocket消息对象
@@ -382,28 +383,11 @@ public class V11OperationHandleRouter {
     private void handleSensorDataReport(MessageProcessingContext context, V11WebsocketMessage message) {
         LocalDateTime now = LocalDateTime.now();
 
-        // 处理数据：可能是List<SensorReport>或JSON字符串
-        List<SensorReport> reports;
-        if (Objects.isNull(message.getData())) {
-            reports = List.of();
-        } else if (message.getData() instanceof List) {
-            @SuppressWarnings("unchecked")
-            List<SensorReport> list = (List<SensorReport>) message.getData();
-            reports = list;
-        } else if (message.getData() instanceof String jsonStr) {
-            // 处理JSON字符串反序列化
-            try {
-                reports = JsonUtils.fromJson(jsonStr, new TypeReference<List<SensorReport>>() {});
-                if (reports == null) {
-                    reports = List.of();
-                }
-            } catch (Exception e) {
-                log.warn("V11Router -ws- 反序列化传感器数据失败: deviceId={}", context.getDeviceId(), e);
-                reports = List.of();
-            }
-        } else {
-            reports = List.of();
-        }
+        // V11协议: data字段直接为List<SensorReport>格式
+        @SuppressWarnings("unchecked")
+        List<SensorReport> reports = Objects.isNull(message.getData())
+                ? List.of()
+                : (List<SensorReport>) message.getData();
 
         terminalReportUseCase.asyncHandleSensorReport(context.getDeviceId(), now, reports);
         log.info("V11Router -ws- #MONITOR_REPORT#【上报监控数据】 deviceId:{}", context.getDeviceId());

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouter.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouter.java
@@ -4,6 +4,7 @@ import com.colorlight.ccloud.program.vo.RpcTerminalProgramVO;
 import com.colorlight.terminal.application.domain.command.TerminalCommand;
 import com.colorlight.terminal.application.domain.connection.MessageProcessingContext;
 import com.colorlight.terminal.application.domain.report.TerminalLog;
+import com.colorlight.terminal.application.domain.sensor.SensorReport;
 import com.colorlight.terminal.application.dto.websocket.v11.V11WebsocketErrorEnum;
 import com.colorlight.terminal.application.dto.websocket.v11.V11WebsocketMessage;
 import com.colorlight.terminal.application.dto.websocket.v11.V11WebsocketMessageTypeEnum;
@@ -380,11 +381,35 @@ public class V11OperationHandleRouter {
      */
     private void handleSensorDataReport(MessageProcessingContext context, V11WebsocketMessage message) {
         LocalDateTime now = LocalDateTime.now();
-        String dataStr = Objects.isNull(message.getData()) ? EMPTY_JSON : JsonUtils.toJson(message.getData());
-        terminalReportUseCase.asyncHandleSensorReport(context.getDeviceId(), now, dataStr);
+
+        // 处理数据：可能是List<SensorReport>或JSON字符串
+        List<SensorReport> reports;
+        if (Objects.isNull(message.getData())) {
+            reports = List.of();
+        } else if (message.getData() instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<SensorReport> list = (List<SensorReport>) message.getData();
+            reports = list;
+        } else if (message.getData() instanceof String jsonStr) {
+            // 处理JSON字符串反序列化
+            try {
+                reports = JsonUtils.fromJson(jsonStr, new TypeReference<List<SensorReport>>() {});
+                if (reports == null) {
+                    reports = List.of();
+                }
+            } catch (Exception e) {
+                log.warn("V11Router -ws- 反序列化传感器数据失败: deviceId={}", context.getDeviceId(), e);
+                reports = List.of();
+            }
+        } else {
+            reports = List.of();
+        }
+
+        terminalReportUseCase.asyncHandleSensorReport(context.getDeviceId(), now, reports);
         log.info("V11Router -ws- #MONITOR_REPORT#【上报监控数据】 deviceId:{}", context.getDeviceId());
         context.sendMessage(new V11WebsocketMessage(V11WebsocketMessageTypeEnum.MONITOR_REPORT.getId(), message.getMessageId()));
     }
+
 
     /**
      * 处理终端日志报告的命令。

--- a/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v10/V10ProtocolMessageProcessorTest.java
+++ b/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v10/V10ProtocolMessageProcessorTest.java
@@ -4,6 +4,7 @@ import com.colorlight.terminal.application.domain.connection.MessageProcessingCo
 import com.colorlight.terminal.application.domain.connection.ProtocolVersion;
 import com.colorlight.terminal.application.domain.connection.TerminalConnection;
 import com.colorlight.terminal.application.domain.sensor.GpsReport;
+import com.colorlight.terminal.application.domain.sensor.SensorReport;
 import com.colorlight.terminal.application.dto.websocket.v10.V10WebsocketMessage;
 import com.colorlight.terminal.application.port.inbound.status.TerminalReportUseCase;
 import com.colorlight.terminal.application.port.outbound.websocket.ProtocolMessageProcessor.TextMessageProcessResult;
@@ -59,7 +60,7 @@ class V10ProtocolMessageProcessorTest {
     private ArgumentCaptor<LocalDateTime> dateTimeCaptor;
     
     @Captor
-    private ArgumentCaptor<String> gpsDataCaptor;
+    private ArgumentCaptor<List> gpsDataCaptor;
     
     @InjectMocks
     private V10ProtocolMessageProcessor processor;
@@ -138,7 +139,7 @@ class V10ProtocolMessageProcessorTest {
         lenient().when(messageProcessingContext.sendMessage(anyString())).thenReturn(true);
         
         // 默认异步处理成功
-        lenient().doNothing().when(terminalReportUseCase).asyncHandleSensorReport(anyLong(), any(LocalDateTime.class), anyString());
+        lenient().doNothing().when(terminalReportUseCase).asyncHandleSensorReport(anyLong(), any(LocalDateTime.class), any(List.class));
     }
     
     @Nested
@@ -258,9 +259,10 @@ class V10ProtocolMessageProcessorTest {
 
             assertThat(deviceIdCaptor.getValue()).isEqualTo(12345L);
             assertThat(dateTimeCaptor.getValue()).isNotNull();
-            // 验证GPS数据被序列化为JSON字符串
-            String expectedGpsJson = JsonUtils.toJson(gpsMessage.getGps());
-            assertThat(gpsDataCaptor.getValue()).isEqualTo(expectedGpsJson);
+            // 验证GPS数据List被正确传递
+            List<SensorReport> capturedGpsData = gpsDataCaptor.getValue();
+            assertThat(capturedGpsData).isNotEmpty();
+            assertThat(capturedGpsData).isEqualTo(new ArrayList<>(gpsMessage.getGps()));
         }
         
         @Test
@@ -278,12 +280,11 @@ class V10ProtocolMessageProcessorTest {
             assertThat(result.success()).isTrue();
             assertThat(result.heartbeat()).isFalse();
 
-            // 验证GPS数据被正确传递（序列化后的JSON字符串）
-            String expectedGpsJson = JsonUtils.toJson(multiGpsMessage.getGps());
+            // 验证GPS数据被正确传递
             verify(terminalReportUseCase).asyncHandleSensorReport(
                 eq(12345L),
                 any(LocalDateTime.class),
-                eq(expectedGpsJson)
+                any(List.class)
             );
         }
         
@@ -305,7 +306,7 @@ class V10ProtocolMessageProcessorTest {
             assertThat(result.heartbeat()).isFalse();
 
             // 验证不调用GPS处理
-            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), anyString());
+            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), any(List.class));
         }
 
         @Test
@@ -326,7 +327,7 @@ class V10ProtocolMessageProcessorTest {
             assertThat(result.heartbeat()).isFalse();
 
             // 验证不调用GPS处理
-            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), anyString());
+            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), any(List.class));
         }
         
         @Test
@@ -338,7 +339,7 @@ class V10ProtocolMessageProcessorTest {
             when(messageProcessingContext.getRawMessage()).thenReturn(jsonMessage);
             
             doThrow(new RuntimeException("GPS处理服务异常"))
-                .when(terminalReportUseCase).asyncHandleSensorReport(anyLong(), any(LocalDateTime.class), anyString());
+                .when(terminalReportUseCase).asyncHandleSensorReport(anyLong(), any(LocalDateTime.class), any(List.class));
             
             // When - 处理GPS消息
             TextMessageProcessResult result = processor.processTextMessage(messageProcessingContext);
@@ -371,7 +372,7 @@ class V10ProtocolMessageProcessorTest {
             assertThat(result.errorMessage()).isNull();
             
             // 验证不调用任何业务处理
-            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), anyString());
+            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), any(List.class));
             verify(messageProcessingContext, never()).sendMessage(anyString());
         }
         
@@ -391,7 +392,7 @@ class V10ProtocolMessageProcessorTest {
             assertThat(result.success()).isTrue();
             assertThat(result.heartbeat()).isFalse();
             
-            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), anyString());
+            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), any(List.class));
         }
     }
     
@@ -415,7 +416,7 @@ class V10ProtocolMessageProcessorTest {
             assertThat(result.errorMessage()).contains("V1.0消息处理异常");
             
             // 验证不调用任何业务处理
-            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), anyString());
+            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), any(List.class));
         }
         
         @Test
@@ -520,7 +521,7 @@ class V10ProtocolMessageProcessorTest {
             assertThat(result.heartbeat()).isTrue();
 
             verify(messageProcessingContext).sendMessage("heartbeat");
-            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), anyString());
+            verify(terminalReportUseCase, never()).asyncHandleSensorReport(anyLong(), any(), any(List.class));
         }
     }
 }

--- a/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouterTest.java
+++ b/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouterTest.java
@@ -27,7 +27,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import com.colorlight.terminal.application.domain.connection.TerminalConnection;
@@ -205,6 +208,40 @@ class V11OperationHandleRouterTest {
             gpsReport2.setSatellites(12);
 
             return Arrays.asList(gpsReport1, gpsReport2);
+        }
+
+        /**
+         * 构建模拟JSON反序列化后的传感器数据（LinkedHashMap格式）
+         * V11WebsocketMessage.data是Object类型，JSON反序列化后得到ArrayList<LinkedHashMap>
+         */
+        public static List<Map<String, Object>> buildSensorReportsAsLinkedHashMaps() {
+            // 模拟GPS报告1的LinkedHashMap表示
+            Map<String, Object> gpsData1 = new LinkedHashMap<>();
+            gpsData1.put("sensorId", 1);
+            gpsData1.put("sensorType", "gps");
+            gpsData1.put("date", "2024-10-21 11:00:00");
+            gpsData1.put("latitude", 39.9042);
+            gpsData1.put("longitude", 116.4074);
+            gpsData1.put("accuracy", 10.0);
+            gpsData1.put("altitude", 100.0);
+            gpsData1.put("speed", 0.0);
+            gpsData1.put("direct", 0.0);
+            gpsData1.put("satellites", 10);
+
+            // 模拟GPS报告2的LinkedHashMap表示
+            Map<String, Object> gpsData2 = new LinkedHashMap<>();
+            gpsData2.put("sensorId", 2);
+            gpsData2.put("sensorType", "gps");
+            gpsData2.put("date", "2024-10-21 11:01:00");
+            gpsData2.put("latitude", 39.9050);
+            gpsData2.put("longitude", 116.4080);
+            gpsData2.put("accuracy", 12.0);
+            gpsData2.put("altitude", 101.0);
+            gpsData2.put("speed", 1.5);
+            gpsData2.put("direct", 45.0);
+            gpsData2.put("satellites", 12);
+
+            return Arrays.asList(gpsData1, gpsData2);
         }
         
         public static List<TerminalLog> buildTerminalLogs() {
@@ -605,24 +642,27 @@ class V11OperationHandleRouterTest {
         }
         
         @Test
-        @DisplayName("应该处理非空的传感器数据上报")
+        @DisplayName("应该处理非空的传感器数据上报（LinkedHashMap反序列化格式）")
         @SuppressWarnings("unchecked")
         void should_handle_sensor_data_report_with_data() {
-            // Given - 准备传感器数据上报消息，data为List<SensorReport>格式
-            List<SensorReport> sensorReports = TestDataBuilder.buildSensorReports();
+            // Given - 准备传感器数据上报消息
+            // 重要：模拟JSON反序列化后的真实格式：ArrayList<LinkedHashMap>而不是SensorReport
+            List<Map<String, Object>> sensorDataMaps = TestDataBuilder.buildSensorReportsAsLinkedHashMaps();
             V11WebsocketMessage sensorMessage = TestDataBuilder.buildMessageWithData(
-                V11WebsocketMessageTypeEnum.MONITOR_REPORT, 5001, sensorReports);
+                V11WebsocketMessageTypeEnum.MONITOR_REPORT, 5001, sensorDataMaps);
 
-            // When - 处理消息
+            // When - 处理消息，handleSensorDataReport会使用JsonUtils.convertValue进行转换
             router.handleMessageByType(messageProcessingContext, sensorMessage);
 
-            // Then - 验证传感器数据处理
+            // Then - 验证传感器数据被正确转换并处理
             @SuppressWarnings("rawtypes")
             ArgumentCaptor<List> sensorReportsCaptor = ArgumentCaptor.forClass(List.class);
             verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), sensorReportsCaptor.capture());
 
             List<?> capturedReports = sensorReportsCaptor.getValue();
-            assertThat(capturedReports).hasSize(2).isEqualTo(sensorReports);
+            assertThat(capturedReports).hasSize(2);
+            // 验证是否成功转换为SensorReport对象
+            assertThat(capturedReports.get(0)).isInstanceOf(SensorReport.class);
 
             verify(messageProcessingContext).sendMessage(messageCaptor.capture());
             V11WebsocketMessage response = messageCaptor.getValue();
@@ -678,6 +718,32 @@ class V11OperationHandleRouterTest {
             V11WebsocketMessage response = messageCaptor.getValue();
             assertThat(response.getType()).isEqualTo(V11WebsocketMessageTypeEnum.MONITOR_REPORT.getId());
             assertThat(response.getReceiptId()).isEqualTo(5003);
+        }
+
+        @Test
+        @DisplayName("应该处理传感器数据转换失败时的情况")
+        @SuppressWarnings("unchecked")
+        void should_handle_sensor_data_conversion_failure() {
+            // Given - 准备无效的传感器数据（无法转换为SensorReport）
+            Map<String, Object> invalidData = new HashMap<>();
+            invalidData.put("invalid", "data");
+            V11WebsocketMessage sensorMessage = TestDataBuilder.buildMessageWithData(
+                V11WebsocketMessageTypeEnum.MONITOR_REPORT, 5004, invalidData);
+
+            // When - 处理消息，转换失败时应该使用空列表
+            router.handleMessageByType(messageProcessingContext, sensorMessage);
+
+            // Then - 验证当转换失败时使用空列表
+            @SuppressWarnings("rawtypes")
+            ArgumentCaptor<List> sensorReportsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), sensorReportsCaptor.capture());
+
+            List<?> capturedReports = sensorReportsCaptor.getValue();
+            assertThat(capturedReports).isEmpty();
+
+            verify(messageProcessingContext).sendMessage(messageCaptor.capture());
+            V11WebsocketMessage response = messageCaptor.getValue();
+            assertThat(response.getType()).isEqualTo(V11WebsocketMessageTypeEnum.MONITOR_REPORT.getId());
         }
         
         @Test

--- a/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouterTest.java
+++ b/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouterTest.java
@@ -239,7 +239,7 @@ class V11OperationHandleRouterTest {
         // 使用doNothing()来配置void方法，避免方法签名问题
         lenient().doNothing().when(terminalReportUseCase).asyncHandleMediaPlayRecordReport(any(Long.class), anyString());
         lenient().doNothing().when(terminalReportUseCase).asyncHandleProgramPlayRecordReport(any(Long.class), anyString());
-        lenient().doNothing().when(terminalReportUseCase).asyncHandleSensorReport(any(Long.class), any(LocalDateTime.class), anyString());
+        lenient().doNothing().when(terminalReportUseCase).asyncHandleSensorReport(any(Long.class), any(LocalDateTime.class), any(List.class));
         lenient().doNothing().when(terminalReportUseCase).asyncSaveTerminalLog(any(Long.class), any());
     }
     
@@ -583,7 +583,7 @@ class V11OperationHandleRouterTest {
             router.handleMessageByType(messageProcessingContext, sensorMessage);
             
             // Then - 验证传感器数据处理
-            verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), anyString());
+            verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), any(List.class));
             verify(messageProcessingContext).sendMessage(messageCaptor.capture());
             
             V11WebsocketMessage response = messageCaptor.getValue();

--- a/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouterTest.java
+++ b/terminal-infrastructure/src/test/java/com/colorlight/terminal/infrastructure/websocket/processor/v11/V11OperationHandleRouterTest.java
@@ -3,6 +3,8 @@ package com.colorlight.terminal.infrastructure.websocket.processor.v11;
 import com.colorlight.terminal.application.domain.command.TerminalCommand;
 import com.colorlight.terminal.application.domain.connection.MessageProcessingContext;
 import com.colorlight.terminal.application.domain.report.TerminalLog;
+import com.colorlight.terminal.application.domain.sensor.GpsReport;
+import com.colorlight.terminal.application.domain.sensor.SensorReport;
 import com.colorlight.terminal.application.dto.websocket.v11.V11WebsocketMessage;
 import com.colorlight.terminal.application.dto.websocket.v11.V11WebsocketMessageTypeEnum;
 import com.colorlight.terminal.application.port.inbound.command.TerminalCommandUseCase;
@@ -166,13 +168,43 @@ class V11OperationHandleRouterTest {
             log1.setDeviceId(12345);
             log1.setLogType("INFO");
             log1.setDescription("系统启动");
-            
+
             TerminalLogDTO log2 = new TerminalLogDTO();
             log2.setDeviceId(12345);
             log2.setLogType("ERROR");
             log2.setDescription("连接失败");
-            
+
             return Arrays.asList(log1, log2);
+        }
+
+        public static List<SensorReport> buildSensorReports() {
+            // 构建GPS报告1
+            GpsReport gpsReport1 = new GpsReport();
+            gpsReport1.setDeviceId(12345L);
+            gpsReport1.setSensorId(1);
+            gpsReport1.setSensorType("gps");
+            gpsReport1.setLatitude(39.9042);
+            gpsReport1.setLongitude(116.4074);
+            gpsReport1.setAccuracy(10.0);
+            gpsReport1.setAltitude(100.0);
+            gpsReport1.setSpeed(0.0);
+            gpsReport1.setDirect(0.0);
+            gpsReport1.setSatellites(10);
+
+            // 构建GPS报告2
+            GpsReport gpsReport2 = new GpsReport();
+            gpsReport2.setDeviceId(12345L);
+            gpsReport2.setSensorId(2);
+            gpsReport2.setSensorType("gps");
+            gpsReport2.setLatitude(39.9050);
+            gpsReport2.setLongitude(116.4080);
+            gpsReport2.setAccuracy(12.0);
+            gpsReport2.setAltitude(101.0);
+            gpsReport2.setSpeed(1.5);
+            gpsReport2.setDirect(45.0);
+            gpsReport2.setSatellites(12);
+
+            return Arrays.asList(gpsReport1, gpsReport2);
         }
         
         public static List<TerminalLog> buildTerminalLogs() {
@@ -573,21 +605,79 @@ class V11OperationHandleRouterTest {
         }
         
         @Test
-        @DisplayName("应该处理传感器数据上报")
-        void should_handle_sensor_data_report() {
-            // Given - 准备传感器数据上报消息
+        @DisplayName("应该处理非空的传感器数据上报")
+        @SuppressWarnings("unchecked")
+        void should_handle_sensor_data_report_with_data() {
+            // Given - 准备传感器数据上报消息，data为List<SensorReport>格式
+            List<SensorReport> sensorReports = TestDataBuilder.buildSensorReports();
             V11WebsocketMessage sensorMessage = TestDataBuilder.buildMessageWithData(
-                V11WebsocketMessageTypeEnum.MONITOR_REPORT, 5001, "{\"temperature\":25.6,\"humidity\":60}");
-            
+                V11WebsocketMessageTypeEnum.MONITOR_REPORT, 5001, sensorReports);
+
             // When - 处理消息
             router.handleMessageByType(messageProcessingContext, sensorMessage);
-            
+
             // Then - 验证传感器数据处理
-            verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), any(List.class));
+            @SuppressWarnings("rawtypes")
+            ArgumentCaptor<List> sensorReportsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), sensorReportsCaptor.capture());
+
+            List<?> capturedReports = sensorReportsCaptor.getValue();
+            assertThat(capturedReports).hasSize(2).isEqualTo(sensorReports);
+
             verify(messageProcessingContext).sendMessage(messageCaptor.capture());
-            
             V11WebsocketMessage response = messageCaptor.getValue();
             assertThat(response.getType()).isEqualTo(V11WebsocketMessageTypeEnum.MONITOR_REPORT.getId());
+            assertThat(response.getReceiptId()).isEqualTo(5001);
+        }
+
+        @Test
+        @DisplayName("应该处理空数据的传感器数据上报")
+        @SuppressWarnings("unchecked")
+        void should_handle_sensor_data_report_with_null_data() {
+            // Given - 准备数据为null的传感器数据上报消息
+            V11WebsocketMessage sensorMessage = TestDataBuilder.buildMessage(V11WebsocketMessageTypeEnum.MONITOR_REPORT, 5002);
+            // data为null
+
+            // When - 处理消息
+            router.handleMessageByType(messageProcessingContext, sensorMessage);
+
+            // Then - 验证使用空列表处理
+            @SuppressWarnings("rawtypes")
+            ArgumentCaptor<List> sensorReportsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), sensorReportsCaptor.capture());
+
+            List<?> capturedReports = sensorReportsCaptor.getValue();
+            assertThat(capturedReports).isEmpty();
+
+            verify(messageProcessingContext).sendMessage(messageCaptor.capture());
+            V11WebsocketMessage response = messageCaptor.getValue();
+            assertThat(response.getType()).isEqualTo(V11WebsocketMessageTypeEnum.MONITOR_REPORT.getId());
+            assertThat(response.getReceiptId()).isEqualTo(5002);
+        }
+
+        @Test
+        @DisplayName("应该处理空列表的传感器数据上报")
+        @SuppressWarnings("unchecked")
+        void should_handle_sensor_data_report_with_empty_list() {
+            // Given - 准备空列表的传感器数据上报消息
+            V11WebsocketMessage sensorMessage = TestDataBuilder.buildMessageWithData(
+                V11WebsocketMessageTypeEnum.MONITOR_REPORT, 5003, Collections.emptyList());
+
+            // When - 处理消息
+            router.handleMessageByType(messageProcessingContext, sensorMessage);
+
+            // Then - 验证处理空列表
+            @SuppressWarnings("rawtypes")
+            ArgumentCaptor<List> sensorReportsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(terminalReportUseCase).asyncHandleSensorReport(eq(12345L), any(LocalDateTime.class), sensorReportsCaptor.capture());
+
+            List<?> capturedReports = sensorReportsCaptor.getValue();
+            assertThat(capturedReports).isEmpty();
+
+            verify(messageProcessingContext).sendMessage(messageCaptor.capture());
+            V11WebsocketMessage response = messageCaptor.getValue();
+            assertThat(response.getType()).isEqualTo(V11WebsocketMessageTypeEnum.MONITOR_REPORT.getId());
+            assertThat(response.getReceiptId()).isEqualTo(5003);
         }
         
         @Test


### PR DESCRIPTION
- 统一使用 SensorReport 对象传递数据，替代原始 JSON 字符串
- 新增协议适配逻辑，支持 {"gps": [...]} 格式数据解析 -优化异常处理机制，提升数据反序列化容错能力
- 调整应用服务层接口参数类型，明确数据结构
- 更新 WebSocket 消息处理器，直接传递 List<SensorReport>
- 修改单元测试用例，适配新的数据传递方式- 移除冗余的 JSON 序列化/反序列化操作，提高性能- 增强 V1.1 协议对多种数据格式的支持能力