### PR TITLE
feat(monitor): 添加WebSocket消息统计功能

### DIFF
--- a/terminal-application/src/main/java/com/colorlight/terminal/application/domain/connection/MessageProcessingContext.java
+++ b/terminal-application/src/main/java/com/colorlight/terminal/application/domain/connection/MessageProcessingContext.java
@@ -141,11 +141,13 @@ public class MessageProcessingContext {
                 WebsocketMsgMetricsHelper.incrementSentMessage();
                 updateSentMessageStatistics();
             } else {
+                WebsocketMsgMetricsHelper.incrementErrorMessage();
                 updateErrorStatistics();
             }
             return success;
         } catch (Exception e) {
             log.warn("MessageProcessingContext - 发送消息失败: deviceId={}", getDeviceId(), e);
+            WebsocketMsgMetricsHelper.incrementErrorMessage();
             updateErrorStatistics();
             return false;
         }

--- a/terminal-application/src/main/java/com/colorlight/terminal/application/domain/connection/MessageProcessingContext.java
+++ b/terminal-application/src/main/java/com/colorlight/terminal/application/domain/connection/MessageProcessingContext.java
@@ -1,5 +1,6 @@
 package com.colorlight.terminal.application.domain.connection;
 
+import com.colorlight.terminal.application.handler.WebsocketMsgMetricsHelper;
 import com.colorlight.terminal.commons.utils.JsonUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -137,6 +138,7 @@ public class MessageProcessingContext {
         try {
             boolean success = connection.sendMessage(message);
             if (success) {
+                WebsocketMsgMetricsHelper.incrementSentMessage();
                 updateSentMessageStatistics();
             } else {
                 updateErrorStatistics();

--- a/terminal-application/src/main/java/com/colorlight/terminal/application/handler/WebsocketMsgMetricsHelper.java
+++ b/terminal-application/src/main/java/com/colorlight/terminal/application/handler/WebsocketMsgMetricsHelper.java
@@ -1,0 +1,47 @@
+package com.colorlight.terminal.application.handler;
+
+import com.colorlight.terminal.commons.exception.technical.TechErrorCode;
+import com.colorlight.terminal.commons.exception.technical.TechnicalException;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * WebSocket消息统计工具类
+ * @author Nan
+ */
+public class WebsocketMsgMetricsHelper {
+
+    private static final AtomicLong totalSentMessage = new AtomicLong(0);
+
+    private static final AtomicLong totalReceivedMessage = new AtomicLong(0);
+
+    private static final AtomicLong totalErrorMessage = new AtomicLong(0);
+
+    private WebsocketMsgMetricsHelper() {
+        throw new TechnicalException(TechErrorCode.INSTANTIATION_IS_PROHIBITED);
+    }
+
+    public static void incrementSentMessage() {
+        totalSentMessage.incrementAndGet();
+    }
+
+    public static void incrementReceivedMessage() {
+        totalReceivedMessage.incrementAndGet();
+    }
+
+    public static void incrementErrorMessage() {
+        totalErrorMessage.incrementAndGet();
+    }
+
+    public static long getTotalSentMessage() {
+        return totalSentMessage.get();
+    }
+
+    public static long getTotalReceivedMessage() {
+        return totalReceivedMessage.get();
+    }
+
+    public static long getTotalErrorMessage() {
+        return totalErrorMessage.get();
+    }
+}

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/monitor/DeviceMetricsService.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/monitor/DeviceMetricsService.java
@@ -6,10 +6,8 @@ import com.colorlight.terminal.application.port.outbound.status.DeviceOnlineStat
 import com.colorlight.terminal.infrastructure.websocket.connection.ShardedConnectionManager;
 import com.colorlight.terminal.infrastructure.websocket.monitor.EventLoopAlertEvent;
 import com.colorlight.terminal.infrastructure.websocket.monitor.EventLoopHealthMonitor;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
+import com.colorlight.terminal.application.handler.WebsocketMsgMetricsHelper;
+import io.micrometer.core.instrument.*;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -110,6 +108,32 @@ public class DeviceMetricsService {
                 .description(MetricsConstant.SYSTEM_METRICS_DESC)
                 .tags(Tags.of(MetricsConstant.TagKey.TYPE, MetricsConstant.SystemType.WEBSOCKET_RATIO))
                 .register(meterRegistry);
+
+        // WebSocket消息发送数
+        FunctionCounter.builder(MetricsConstant.TERMINAL_SYSTEM_METRICS,
+                        WebsocketMsgMetricsHelper.class,
+                        helper -> (double) WebsocketMsgMetricsHelper.getTotalSentMessage())
+                .description(MetricsConstant.SYSTEM_METRICS_DESC)
+                .tags(Tags.of(MetricsConstant.TagKey.TYPE, MetricsConstant.SystemType.WEBSOCKET_MSG_SENT))
+                .register(meterRegistry);
+
+        // WebSocket消息接收数
+        FunctionCounter.builder(MetricsConstant.TERMINAL_SYSTEM_METRICS,
+                        WebsocketMsgMetricsHelper.class,
+                        helper -> (double) WebsocketMsgMetricsHelper.getTotalReceivedMessage())
+                .description(MetricsConstant.SYSTEM_METRICS_DESC)
+                .tags(Tags.of(MetricsConstant.TagKey.TYPE, MetricsConstant.SystemType.WEBSOCKET_MSG_RECEIVED))
+                .register(meterRegistry);
+
+        // WebSocket错误消息数
+        FunctionCounter.builder(MetricsConstant.TERMINAL_SYSTEM_METRICS,
+                        WebsocketMsgMetricsHelper.class,
+                        helper -> (double) WebsocketMsgMetricsHelper.getTotalErrorMessage())
+                .description(MetricsConstant.SYSTEM_METRICS_DESC)
+                .tags(Tags.of(MetricsConstant.TagKey.TYPE, MetricsConstant.SystemType.WEBSOCKET_MSG_ERROR))
+                .register(meterRegistry);
+
+
     }
 
     /**

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/monitor/MetricsConstant.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/monitor/MetricsConstant.java
@@ -91,6 +91,9 @@ public final class MetricsConstant {
         public static final String WEBSOCKET_CONNECTIONS = "websocket_connections";
         public static final String ONLINE_DEVICES = "online_devices";
         public static final String WEBSOCKET_RATIO = "websocket_ratio";
+        public static final String WEBSOCKET_MSG_SENT = "websocket_msg_sent";
+        public static final String WEBSOCKET_MSG_RECEIVED = "websocket_msg_received";
+        public static final String WEBSOCKET_MSG_ERROR = "websocket_msg_error";
 
         private SystemType() {
         }

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/handler/NettyWebsocketFrameHandler.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/handler/NettyWebsocketFrameHandler.java
@@ -111,6 +111,7 @@ public class NettyWebsocketFrameHandler extends SimpleChannelInboundHandler<WebS
                         frame.getClass().getSimpleName(), deviceId);
             }
         } catch (Exception e) {
+            WebsocketMsgMetricsHelper.incrementErrorMessage();
             log.error("NettyWebsocketFrameHandler - 处理WebSocket帧失败: deviceId={}", deviceId, e);
         } finally {
             // 增加接收消息计数

--- a/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/handler/NettyWebsocketFrameHandler.java
+++ b/terminal-infrastructure/src/main/java/com/colorlight/terminal/infrastructure/websocket/handler/NettyWebsocketFrameHandler.java
@@ -8,6 +8,7 @@ import com.colorlight.terminal.application.port.outbound.connection.ConnectionMa
 import com.colorlight.terminal.infrastructure.security.authentication.TerminalPrincipal;
 import com.colorlight.terminal.infrastructure.websocket.auth.NettyWebsocketAuthHandler;
 import com.colorlight.terminal.infrastructure.websocket.connection.TerminalWebsocketSession;
+import com.colorlight.terminal.application.handler.WebsocketMsgMetricsHelper;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -104,11 +105,16 @@ public class NettyWebsocketFrameHandler extends SimpleChannelInboundHandler<WebS
             } else if (frame instanceof CloseWebSocketFrame) {
                 handleCloseFrame(ctx, deviceId);
             } else {
+                // 增加错误消息计数
+                WebsocketMsgMetricsHelper.incrementErrorMessage();
                 log.warn("NettyWebsocketFrameHandler - 不支持的WebSocket帧类型: {}, deviceId: {}",
                         frame.getClass().getSimpleName(), deviceId);
             }
         } catch (Exception e) {
             log.error("NettyWebsocketFrameHandler - 处理WebSocket帧失败: deviceId={}", deviceId, e);
+        } finally {
+            // 增加接收消息计数
+            WebsocketMsgMetricsHelper.incrementReceivedMessage();
         }
     }
 


### PR DESCRIPTION
- 新增WebSocket消息发送、接收和错误计数器
- 引入WebsocketMsgMetricsHelper工具类用于统计消息数量
- 在DeviceMetricsService中注册新的监控指标
- 在消息处理上下文和WebSocket帧处理器中增加统计逻辑
- 扩展MetricsConstant系统类型标签定义
- 实现FunctionCounter来跟踪WebSocket消息指标